### PR TITLE
LON0x20: Add Blixa write-up

### DIFF
--- a/ctf-solutions/LON0x20/Daviey/Blixa/README.md
+++ b/ctf-solutions/LON0x20/Daviey/Blixa/README.md
@@ -1,0 +1,105 @@
+Blixa
+=====
+
+This is a "Crypto" type challenge, where the premise is that a lottery draw of
+6 numbers (between 0 and 255) is drawn every minute, hence the fancy banner of
+"Minute Lotto".
+
+The source code for the server component is provided and it is golang.  There
+is a public service running on `c.ctf.turtleturtleup.com:1339`.
+
+Reading the source code we can see that if we match the correct 6 numbers, then
+then flag is returned which is stored as an environmental variable as "FLAG".
+Therefore, we know that local exploitation will not be possible as the FLAG
+isn't related to the source and is dependant on the remote environment.
+
+On the imports, we can see ["math/rand"](https://golang.org/pkg/math/rand/) which is well known for producing
+pseudo-random rather than the library ["crypto/rand"](https://golang.org/pkg/crypto/rand/) which produces
+cryptographically secure randomisation.  Infact, the description for the
+"math/rand" package states "use a default shared Source that produces a
+deterministic sequence of values each time a program is run"
+
+Therefore, we can expect to look for some issue with the random selection.
+
+Understanding the seed
+----------------------
+
+On Line 21 of the server code, we see:
+`var globalSeed = rand.New(rand.NewSource(time.Now().UnixNano())).Int63n(999999)`
+
+Working from the inside out, we see that the parameter of
+`time.Now().UnixNano()`, which is the current Unix time (epoch time) in
+nanoseconds, or the number of nanoseconds elapsed since January 1, 1970 UTC.
+
+An example of this is: 1257894000000000000, which is 2009-11-10 23:00:00 +0000
+UTC.
+
+Then `rand.NewSource()` produces a pseudo-random Source, seeded with a value
+derived from the current time in nanoseconds.  This Source is then used to
+return an Int63n, which is a non-negative pseudo-random number, with the
+maximum value being 999999.  Therefore, we know that the globalSeed will be
+between 1 and 999999.
+
+To confirm that this is the weakness, we can hard-code the globalSeed and run
+the server component and we should see a consistent stream of draw results.
+However, we don't. :(
+
+Understanding each draw
+-----------------------
+
+Now we have a consistent seed, we can see that each draw isn't fully dependant
+on this source alone.
+
+On Line 118 of the server code, we see:
+`r := rand.New(rand.NewSource(globalSeed + time.Now().Truncate(time.Minute).Unix()))`
+
+This adds the current time, which is truncated to the nearest minute (drops the
+seconds) and represented in Unix time.  This means that each run the
+deterministic random number is derived from `globalSeed + CurrentTime`, which
+increments each time there is a draw by 60 seconds.
+
+If we hard-code the current time in addition to the globalSeed, we can now see
+that each time the tool is run a deterministic series of draws is returned.
+
+Reversing the results to find the seed
+--------------------------------------
+
+We know that a deterministic stream is created by:
+
+`globalSeed + CurrentTime = Results`
+
+We know the draw results, as they are returned by the server every minute.  We
+also know the current time by checking our local time.
+
+The truncation of the current time to the nearest minute makes it much easier
+to be able to reverse the results.  This is because it would be very difficult
+to be sure of the server time to the nearest second, but we can be pretty
+confident out local machine and the server are running to the same minute.
+
+Therefore, if we take the CurrentTime and enumerate over every possible
+globalSeed, using the same formula we should be able to intercept the draw
+results.  This will confirm the servers globalSeed.
+
+We can see this implemented in the getCurrentSeed() function in the attached
+code.
+
+Predicting the future
+---------------------
+
+Now we are able to determine the server's globalSeed, we are able to produce
+the draw results in paraell to the server.  However, this doesn't help us work
+out what the next results will be.
+
+However, due to the time truncation to the nearest minute we know that adding
+60, 120 & 180 to the CurrentTime will return to us the next 3 draw results
+without having to wait.
+
+This is implemented in the predictNext() code in the attached code.
+
+Interesting Caveat
+------------------
+
+The [Go Playground](https://play.golang.org) is an excellent resource for experimental go code.  However,
+the Go Playground is a fully deterministic environment which means that the
+current time is a constant of "2009-11-10 23:00:00 UTC" which is Go's birthday.
+This means that the client code needs to be run locally.

--- a/ctf-solutions/LON0x20/Daviey/Blixa/main.go
+++ b/ctf-solutions/LON0x20/Daviey/Blixa/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func getCurrentDraw() ([]uint8, int64) {
+
+	// take the input
+	fmt.Println("# Connect to 'c.ctf.turtleturtleup.com:1339' and enter some guess")
+	fmt.Println("# Wait for the draw to happen and copy the result")
+	fmt.Println("# Something like: '25 13 106 174 234 30' (no brackets or quote)")
+	fmt.Println("# It needs to be from the current minute or it will not work:")
+	reader := bufio.NewReader(os.Stdin)
+
+	t, _ := reader.ReadString('\n')
+
+	// remove the nasty carriage return
+	t = strings.Replace(t, "\n", "", -1)
+	t1 := strings.Fields(t)
+
+	var currentDraw = []uint8{}
+	// convert it from a flat string to a slice of uint8
+	for _, i := range t1 {
+		j, err := strconv.Atoi(i)
+		if err != nil {
+			panic(err)
+		}
+		currentDraw = append(currentDraw, uint8(j))
+	}
+
+	// grab the current unix time (rounded to the nearest minute)
+	var currentTime int64
+	currentTime = time.Now().Truncate(time.Minute).Unix()
+
+	return currentDraw, currentTime
+
+}
+
+func getCurrentSeed(currentDraw []uint8, currentTime int64) int64 {
+
+	fmt.Println("# One moment, calculating")
+
+	// We know the seed must be between 1 and 999999, so lets loop through
+	for globalSeed := 1; globalSeed <= 999999; globalSeed++ {
+		//fmt.Println(globalSeed)
+
+		draw := make([]uint8, 6)
+
+		r := rand.New(rand.NewSource(int64(globalSeed) + currentTime))
+		binary.Read(r, binary.LittleEndian, &draw)
+
+		// if it matches, we have found the seed
+		if reflect.DeepEqual(draw, currentDraw) {
+			fmt.Print("The globalSeed is: ")
+			fmt.Println(globalSeed)
+			return int64(globalSeed)
+
+		}
+
+	}
+
+	return 0
+}
+
+func predictNext(globalSeed int64) {
+
+	draw := make([]uint8, 6)
+
+	fmt.Println("The next balls are: ")
+
+	// guess the next 3 draws
+	times := []int64{60, 120, 180} //60 second increments
+	for _, t := range times {
+
+		// Add the times to the current time to predict the future
+		r := rand.New(rand.NewSource(globalSeed + time.Now().Truncate(time.Minute).Unix() + t))
+		binary.Read(r, binary.LittleEndian, &draw)
+
+		fmt.Println(draw)
+
+	}
+}
+
+func main() {
+	// take input of the current balls
+	currentDraw, currentTime := getCurrentDraw()
+
+	// Work out the current seed based on the time and last draw
+	globalSeed := getCurrentSeed(currentDraw, currentTime)
+
+	// predict the next balls
+	predictNext(globalSeed)
+
+}


### PR DESCRIPTION
Write up of one of the "crypto" challenges from the SecTalks
LON meetup from 27th June 2019.

The challenge was Blixa (aka "Minute Lotto").

Included is a write-up, but also a solution in golang.

Signed-off-by: Dave Walker <email@daviey.com>